### PR TITLE
themes.js: add Viridis theme

### DIFF
--- a/src/themes.js
+++ b/src/themes.js
@@ -98,5 +98,15 @@ export const themes = {
     grade2: "#ca5bcc",
     grade1: "#e48bdc",
     grade0: "#ebedf0"
+  },
+  viridis: {
+    background: "#ffffff",
+    text: "#000000",
+    meta: "#666666",
+    grade4: "#440154",
+    grade3: "#3b528b",
+    grade2: "#21918c",
+    grade1: "#5ec962",
+    grade0: "#fde725"
   }
 };


### PR DESCRIPTION
Add matplotlib's perceptually uniform Viridis colormap. A good description of this palette can be found at [Better than the rainbow: The Matplotlib alternative colormaps](http://medvis.org/2016/02/23/better-than-the-rainbow-the-matplotlib-alternative-colormaps/).

To generate the five colors along the Viridis spectrum, I used the excellent [tool](https://gist.github.com/adam-garcia/8d8eded299ec5e16752d04281236b151) by @adam-garcia. 