### PR TITLE
README: link to themes.js and sync list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,18 @@ drawContributions(canvasEl, {
 
 ## Available Themes
 
+The themes are defined in the [`src/themes.js`](src/themes.js) file.
+Currently the available themes are:
+
 - `standard`
-- `teal`
 - `halloween`
+- `teal`
 - `leftPad`
-- `panda`
-- `blue`
 - `dracula`
+- `blue`
+- `panda`
+- `sunny`
+- `pink`
 
 ## Data Format
 


### PR DESCRIPTION
The list of themes in the README was both incomplete and sorted in a different way from the actual list of themes defined in the themes.js file. This change updates the list of themes in the README to match that file.

Hopefully having the link to the file in the README might also remind people who submit themes that this list needs to be updated too :)