### PR TITLE
Add YlGnBu theme from ColorBrewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Currently the available themes are:
 - `panda`
 - `sunny`
 - `pink`
+- `YlGnBu`
 
 ## Data Format
 

--- a/src/themes.js
+++ b/src/themes.js
@@ -98,5 +98,15 @@ export const themes = {
     grade2: "#ca5bcc",
     grade1: "#e48bdc",
     grade0: "#ebedf0"
+  },
+  YlGnBu: { // http://colorbrewer2.org/#type=sequential&scheme=YlGnBu&n=5
+    background: "#ffffff",
+    text: "#000000",
+    meta: "#666666",
+    grade4: "#253494",
+    grade3: "#2c7fb8",
+    grade2: "#41b6c4",
+    grade1: "#a1dab4",
+    grade0: "#ebedf0"
   }
 };


### PR DESCRIPTION
I find this theme quite pleasant, and a nice, fresher alternative to the default theme. It's built from the [5-class YlGnBu](http://colorbrewer2.org/#type=sequential&scheme=YlGnBu&n=5) color scheme from ColorBrewer, with the lighter shade (a near-white, yellowish `#ffffcc`) replaced by the soft gray already used in most of the other themes, `#ebedf0`. The color scheme is color-blind friendly and print friendly, which is a nice plus.

Here's a screenshot:

![ylgnbu](https://user-images.githubusercontent.com/478237/47052385-ee21d500-d19f-11e8-9999-9721eb80ff4e.png)
