### PR TITLE
feat: Implemented custom themes. (#16)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,19 @@ import moment from "moment";
 import { themes } from "./themes";
 
 function getTheme(opts = {}) {
-  const { themeName } = opts;
+  const { themeName, customTheme } = opts;
+  if (customTheme) {
+    return {
+      background: customTheme.background || themes.standard.background,
+      text: customTheme.text || themes.standard.text,
+      meta: customTheme.meta || themes.standard.meta,
+      grade4: customTheme.grade4 || themes.standard.grade4,
+      grade3: customTheme.grade3 || themes.standard.grade3,
+      grade2: customTheme.grade2 || themes.standard.grade2,
+      grade1: customTheme.grade1 || themes.standard.grade1,
+      grade0: customTheme.grade0 || themes.standard.grade0
+    };
+  }
   if (themeName in themes) {
     return themes[themeName];
   }


### PR DESCRIPTION
This PR closes #16 and lets you define custom themes while calling the method.

This is an example for drawing a contributions chart with custom colors (although the colors specified here are equal to the standard theme):
```js
import { drawContributions } from "github-contributions-canvas";

drawContributions(canvasEl, {
  data: contributionData,
  username: "myusername",
  customTheme: {
    background: "#ffffff",
    text: "#000000",
    meta: "#666666",
    grade4: "#196127",
    grade3: "#239a3b",
    grade2: "#7bc96f",
    grade1: "#c6e48b",
    grade0: "#ebedf0"
  },
  footerText: "Now with custom colors!"
});
```

Colors not specified will default to the standard theme.